### PR TITLE
新增命令行界面 (CLI) 和中文简繁转换功能

### DIFF
--- a/ConverTtoS.py
+++ b/ConverTtoS.py
@@ -1,0 +1,17 @@
+import argparse
+
+from utils import ChineseConverter
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert between Simplified and Traditional Chinese in text files.")
+    parser.add_argument("input_file_path", type=str, help="Path to the input file.")
+    parser.add_argument("output_file_path", type=str, help="Path to the output file.")
+    parser.add_argument("--conversion_type", type=str, choices=["s2t", "t2s"], default="s2t",
+                        help="Conversion type. 's2t' for Simplified to Traditional (default). 't2s' for Traditional to Simplified.")
+
+    args = parser.parse_args()
+
+    converter = ChineseConverter()
+    converter.convert_file(args.input_file_path, args.output_file_path, args.conversion_type)

--- a/ConverTtoS.py
+++ b/ConverTtoS.py
@@ -1,3 +1,14 @@
+"""
+传入参数:
+    --input-file-path:需要翻译的文件的路径+名字
+    --output-fie-path:翻译之后文件的路径+名字
+    --conversion-type:翻译类型,t2s:繁体转简体
+                            s2t:简体转繁体
+
+
+"""
+
+
 import argparse
 
 from utils import ChineseConverter
@@ -6,9 +17,9 @@ from utils import ChineseConverter
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert between Simplified and Traditional Chinese in text files.")
-    parser.add_argument("input_file_path", type=str, help="Path to the input file.")
-    parser.add_argument("output_file_path", type=str, help="Path to the output file.")
-    parser.add_argument("--conversion_type", type=str, choices=["s2t", "t2s"], default="s2t",
+    parser.add_argument("--input-file-path", type=str, help="Path to the input file.")
+    parser.add_argument("--output-file-path", type=str, help="Path to the output file.")
+    parser.add_argument("--conversion-type", type=str, choices=["s2t", "t2s"], default="t2s",
                         help="Conversion type. 's2t' for Simplified to Traditional (default). 't2s' for Traditional to Simplified.")
 
     args = parser.parse_args()

--- a/cli.py
+++ b/cli.py
@@ -22,7 +22,7 @@ class cli_process:
     DEFAULT_PARAM_OUTPUT_TEXT = "output_text"
     DEFAULT_PARAM_OUTPUT_TEXT_NAME = "output.txt"
     DEFAULT_PARAM_OUTPUT_TEXT_DIR = "./outputs"
-    DEFAULT_PARAM_BEAM_SIZE = 4;
+    DEFAULT_PARAM_BEAM_SIZE = 4
     def __init__(self, model_name = None, model_dir=None, input_text_name=None, input_text_content=None, input_text_dir = None, output_text_name=None,
                  output_text_content=None, output_text_dir=None,device='cpu',beam_size=None):
         self.model = Model(model_name or self.DEFAULT_PARAM_MODEL_NAME,
@@ -37,91 +37,46 @@ class cli_process:
                                 output_text_dir or self.DEFAULT_PARAM_OUTPUT_TEXT_DIR)
         self.device = device
         self.beam_size = beam_size or self.DEFAULT_PARAM_BEAM_SIZE
+        self.translator = None;
 
-    # For input_text
-    def set_model_name(self, model_name):
-        self.model.name = model_name
+    def get_model_path(self):
+        return os.path.join(self.model.dir, self.model.name)
 
-    def get_model_name(self):
-        return self.model.name
+    def get_input_text_path(self):
+        file_path = os.path.join(self.input_text.dir, self.input_text.name)
+        return file_path
 
-    def set_model_dir(self, model_dir):
-        self.model.dir = model_dir
-
-    def get_model_dir(self):
-        return self.model.dir
-
-    def set_input_text_name(self, input_text_name):
-        self.input_text.name = input_text_name
-
-    def get_input_text_name(self):
-        return self.input_text.name
-
-    def set_input_text_content(self, input_text_content):
-        self.input_text.content = input_text_content
-
-    def get_input_text_content(self):
-        return self.input_text.content
-
-    def set_input_text_dir(self, input_text_dir):
-        self.input_text.dir = input_text_dir
-
-    def get_input_text_dir(self):
-        return self.input_text.dir
-
-    # For output_text
-    def set_output_text_name(self, output_text_name):
-        self.output_text.name = output_text_name
-
-    def get_output_text_name(self):
-        return self.output_text.name
-
-    def set_output_text_content(self, output_text_content):
-        self.output_text.content = output_text_content
-
-    def get_output_text_content(self):
-        return self.output_text.content
-
-    def set_output_text_dir(self, output_text_dir):
-        self.output_text.dir = output_text_dir
-
-    def get_output_text_dir(self):
-        return self.output_text.dir
-
-    def set_beam_size(self, beam_size):
-        self.beam_size = beam_size
-
-    def get_beam_size(self):
-        return self.beam_size
-
-    def set_device(self, device):
-        self.output_text.dir = device
-
-    def get_deivce(self):
-        return self.device
+    def get_output_text_path(self):
+        file_path = os.path.join(self.output_text.dir, self.output_text.name)
+        return file_path
 
     def load_model(self):
-        model_dir = self.get_model_dir()
+        model_dir = self.get_model_path()
         try:
             self.translator = Translator(model_dir, self.device)
             if self.translator.tokenizer is None:
-                print("")
-                return
+
+                print("Error loading model: None tokenizer")
+
+            return
             if self.translator.cleaner is None:
-                print("")
+                print("Error loading model: None cleaner")
                 return
 
             self.max_text_length = self.translator.config['max_len'][0]
 
-        except:
-           print("")
+
+        except Exception as e:
+            print(f"Error loading model: {e}")
 
     def run(self):
         if self.model is None or self.translator is None:
             return
 
         def _translate():
-            translated_texts = self.translator.translate(self.input_text.content, self.beam_size, self.device)
+            origin_text_dir = self.get_input_text_path()
+            output_text_dir = self.get_output_text_path()
+            translated_texts = self.translator.translate_file(file=origin_text_dir,output=output_text_dir, beam_size = self.beam_size, device=self.device)
             if translated_texts is None:
                 return
 
@@ -137,6 +92,9 @@ class cli_process:
             print(f"Translated text saved to: {output_path}")
 
         _translate()
+
+
+
 
 
 def main(args):

--- a/cli.py
+++ b/cli.py
@@ -1,8 +1,48 @@
-# import torch
+"""
+该代码实现了一个命令行界面 (CLI)，用于执行文本翻译任务。
+
+参数(args)说明:
+    --model-name: 模型的名称，默认为 'value1'。
+    --model-dir: 存放模型的目录，默认为 './models'。
+    --input-text-name: 输入文本的文件名，默认为 'input.txt'。
+    --input-text-content: 输入文本的内容，默认为 'input_text'。
+    --input-text-dir: 输入文本的目录，默认为 './inputs'。
+    --output-text-name: 输出文本的文件名，默认为 'output.txt'。
+    --output-text-dir: 输出文本的目录，默认为 './outputs'。
+    --device: 用于翻译的设备 (例如, 'cpu', 'cuda')，默认为 'cpu'。
+    --beam-size: beam搜索的大小，默认为 4。
+
+函数解释:
+1. Text: 代表文本的类，有三个属性：文件名(name)、内容(content)和目录(dir)。
+2. Model: 代表模型的类，有两个属性：名称(name)和目录(dir)。
+3. cli_process: 主处理类，其中:
+    - 初始化 (__init__): 创建模型、输入文本和输出文本的实例，并初始化翻译器。
+    - get_model_path: 获取模型的完整路径。
+    - get_input_text_path: 获取输入文本的完整路径。
+    - get_output_text_path: 获取输出文本的完整路径。
+    - load_model: 加载翻译模型。
+    - run: 执行翻译并保存结果。
+
+4. main: 主函数，用于从命令行接收参数，初始化 cli_process 类并执行翻译。
+
+如何运行:
+你可以通过以下的方式执行代码:
+```bash
+python cli.py --model-name=LNTW_ja2zh --model-dir=./models --input-text-name="test.txt"
+--input-text-dir="./" --output-text-name="output_test.txt" --output-text-dir="./output" --device=cuda
+"""
+
+
 import argparse
 import os
 
 from utils import Translator
+
+
+
+
+
+
 class Text:
     def __init__(self, name, content, dir):
         self.name = name

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,185 @@
+# import torch
+import argparse
+import os
+
+from utils import Translator
+class Text:
+    def __init__(self, name, content, dir):
+        self.name = name
+        self.content = content
+        self.dir = dir
+
+class Model:
+    def __init__(self, name, dir):
+        self.name = name
+        self.dir = dir
+class cli_process:
+    DEFAULT_PARAM_MODEL_NAME = "value1"
+    DEFAULT_PARAM_MODEL_DIR = "./models"
+    DEFAULT_PARAM_INPUT_TEXT = "input_text"
+    DEFAULT_PARAM_INPUT_TEXT_NAME = "input.txt"
+    DEFAULT_PARAM_INPUT_TEXT_DIR = "./inputs"
+    DEFAULT_PARAM_OUTPUT_TEXT = "output_text"
+    DEFAULT_PARAM_OUTPUT_TEXT_NAME = "output.txt"
+    DEFAULT_PARAM_OUTPUT_TEXT_DIR = "./outputs"
+    DEFAULT_PARAM_BEAM_SIZE = 4;
+    def __init__(self, model_name = None, model_dir=None, input_text_name=None, input_text_content=None, input_text_dir = None, output_text_name=None,
+                 output_text_content=None, output_text_dir=None,device='cpu',beam_size=None):
+        self.model = Model(model_name or self.DEFAULT_PARAM_MODEL_NAME,
+                           model_dir or self.DEFAULT_PARAM_MODEL_DIR)
+
+        self.input_text = Text(input_text_name or self.DEFAULT_PARAM_INPUT_TEXT_NAME,
+                               input_text_content or self.DEFAULT_PARAM_INPUT_TEXT,
+                               input_text_dir or self.DEFAULT_PARAM_INPUT_TEXT_DIR)
+
+        self.output_text = Text(output_text_name or self.DEFAULT_PARAM_OUTPUT_TEXT_NAME,
+                                output_text_content or self.DEFAULT_PARAM_OUTPUT_TEXT,
+                                output_text_dir or self.DEFAULT_PARAM_OUTPUT_TEXT_DIR)
+        self.device = device
+        self.beam_size = beam_size or self.DEFAULT_PARAM_BEAM_SIZE
+
+    # For input_text
+    def set_model_name(self, model_name):
+        self.model.name = model_name
+
+    def get_model_name(self):
+        return self.model.name
+
+    def set_model_dir(self, model_dir):
+        self.model.dir = model_dir
+
+    def get_model_dir(self):
+        return self.model.dir
+
+    def set_input_text_name(self, input_text_name):
+        self.input_text.name = input_text_name
+
+    def get_input_text_name(self):
+        return self.input_text.name
+
+    def set_input_text_content(self, input_text_content):
+        self.input_text.content = input_text_content
+
+    def get_input_text_content(self):
+        return self.input_text.content
+
+    def set_input_text_dir(self, input_text_dir):
+        self.input_text.dir = input_text_dir
+
+    def get_input_text_dir(self):
+        return self.input_text.dir
+
+    # For output_text
+    def set_output_text_name(self, output_text_name):
+        self.output_text.name = output_text_name
+
+    def get_output_text_name(self):
+        return self.output_text.name
+
+    def set_output_text_content(self, output_text_content):
+        self.output_text.content = output_text_content
+
+    def get_output_text_content(self):
+        return self.output_text.content
+
+    def set_output_text_dir(self, output_text_dir):
+        self.output_text.dir = output_text_dir
+
+    def get_output_text_dir(self):
+        return self.output_text.dir
+
+    def set_beam_size(self, beam_size):
+        self.beam_size = beam_size
+
+    def get_beam_size(self):
+        return self.beam_size
+
+    def set_device(self, device):
+        self.output_text.dir = device
+
+    def get_deivce(self):
+        return self.device
+
+    def load_model(self):
+        model_dir = self.get_model_dir()
+        try:
+            self.translator = Translator(model_dir, self.device)
+            if self.translator.tokenizer is None:
+                print("")
+                return
+            if self.translator.cleaner is None:
+                print("")
+                return
+
+            self.max_text_length = self.translator.config['max_len'][0]
+
+        except:
+           print("")
+
+    def run(self):
+        if self.model is None or self.translator is None:
+            return
+
+        def _translate():
+            translated_texts = self.translator.translate(self.input_text.content, self.beam_size, self.device)
+            if translated_texts is None:
+                return
+
+            # 输出到控制台
+            for idx, text in enumerate(translated_texts):
+                print(f"Option {idx + 1}: {text}")
+
+            # 保存翻译到指定的文件
+            output_path = os.path.join(self.output_text.dir, self.output_text.name)
+            with open(output_path, 'w', encoding='utf-8') as f:
+                for text in translated_texts:
+                    f.write(text + '\n')
+            print(f"Translated text saved to: {output_path}")
+
+        _translate()
+
+
+def main(args):
+    cli = cli_process(model_name=args.model_name,
+                      model_dir=args.model_dir,
+                      input_text_name=args.input_text_name,
+                      input_text_content=args.input_text_content,
+                      input_text_dir=args.input_text_dir,
+                      output_text_name=args.output_text_name,
+                      output_text_dir=args.output_text_dir,
+                      device=args.device,
+                      beam_size=args.beam_size)
+
+    cli.load_model()
+    cli.run()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Command-line interface for translation.')
+
+    # Model arguments
+    parser.add_argument('--model-name', default=cli_process.DEFAULT_PARAM_MODEL_NAME, help='Name of the model.')
+    parser.add_argument('--model-dir', default=cli_process.DEFAULT_PARAM_MODEL_DIR, help='Directory of the model.')
+
+    # Input text arguments
+    parser.add_argument('--input-text-name', default=cli_process.DEFAULT_PARAM_INPUT_TEXT_NAME,
+                        help='Name of the input text file.')
+    parser.add_argument('--input-text-content', default=cli_process.DEFAULT_PARAM_INPUT_TEXT,
+                        help='Content of the input text.')
+    parser.add_argument('--input-text-dir', default=cli_process.DEFAULT_PARAM_INPUT_TEXT_DIR,
+                        help='Directory of the input text file.')
+
+    # Output text arguments
+    parser.add_argument('--output-text-name', default=cli_process.DEFAULT_PARAM_OUTPUT_TEXT_NAME,
+                        help='Name of the output text file.')
+    parser.add_argument('--output-text-dir', default=cli_process.DEFAULT_PARAM_OUTPUT_TEXT_DIR,
+                        help='Directory of the output text file.')
+
+    # Translation arguments
+    parser.add_argument('--device', default='cpu', help='Device to use for translation (e.g., cpu, cuda).')
+    parser.add_argument('--beam-size', type=int, default=cli_process.DEFAULT_PARAM_BEAM_SIZE,
+                        help='Size of the beam for beam search.')
+
+    args = parser.parse_args()
+    main(args)
+

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,8 @@ import cleaner
 from model import init_model
 from beam_decoder import beam_search
 
+
+
 class Translator:
     def __init__(self, model_dir, device='cpu'):
         self._is_terminated = False
@@ -75,4 +77,50 @@ class Translator:
                         text = line
         except UnicodeDecodeError:
             print(f"Error decoding file: {file}. It may contain characters that are not UTF-8 encoded.")
+
+
+import opencc
+
+
+class ChineseConverter:
+    def __init__(self):
+        self.s2t_converter = opencc.OpenCC('s2t')  # 简体到繁体
+        self.t2s_converter = opencc.OpenCC('t2s')  # 繁体到简体
+
+    def convert(self, content, conversion_type='s2t'):
+        """
+        Convert the Chinese characters in content from Simplified to Traditional or vice versa.
+
+        Args:
+        - content (str): The text to be converted.
+        - conversion_type (str): 's2t' for Simplified to Traditional, 't2s' for Traditional to Simplified.
+
+        Returns:
+        - str: Converted text.
+        """
+        if conversion_type == 's2t':
+            return self.s2t_converter.convert(content)
+        elif conversion_type == 't2s':
+            return self.t2s_converter.convert(content)
+        else:
+            raise ValueError("Invalid conversion_type. Must be either 's2t' or 't2s'.")
+
+    def convert_file(self, input_file_path, output_file_path, conversion_type='s2t'):
+        """
+        Convert the Chinese characters in a file from Simplified to Traditional or vice versa.
+
+        Args:
+        - input_file_path (str): Path to the input file.
+        - output_file_path (str): Path to the output file.
+        - conversion_type (str): 's2t' for Simplified to Traditional, 't2s' for Traditional to Simplified.
+        """
+        with open(input_file_path, 'r', encoding='utf-8') as file:
+            content = file.read()
+
+        converted_content = self.convert(content, conversion_type)
+
+        with open(output_file_path, 'w', encoding='utf-8') as file:
+            file.write(converted_content)
+
+
 


### PR DESCRIPTION
### 描述
为了简化服务器上的部署推理过程，本次PR主要完成了以下内容：
1. **命令行界面 (CLI)**: 使用户能够通过命令行更加方便地与翻译系统交互。
2. **中文简繁转换 (ChineseConvert)**: 允许用户在简体中文和繁体中文之间进行转换。

### 主要更改
- `cli.py`: 新增命令行界面模块，支持参数传入、模型加载、输入输出文件路径的解析等功能。
- 在`utils.py`中新增了基于opencc的翻译类`ChineseConvert`
- `ConvertTtoS.py`: 提供了基于`utils`接口的文件级别的中文简繁转换功能。


### 使用方法
1.进行日中翻译
```bash
python cli.py --model-name=LNTW_ja2zh --model-dir=./models --input-text-name="test.txt"
--input-text-dir="./" --output-text-name="output_test.txt" --output-text-dir="./output" --device=cuda
```

其中，参数描述如下：
```
- `--model-name`: 指定模型的名称，默认为 'value1'。
- `--model-dir`: 指定存放模型的目录，默认为 './models'。
- `--input-text-name`: 输入文本的文件名，默认为 'input.txt'。
- `--input-text-content`: 输入文本的内容，默认为 'input_text'。
- `--input-text-dir`: 输入文本的目录，默认为 './inputs'。
- `--output-text-name`: 输出文本的文件名，默认为 'output.txt'。
- `--output-text-dir`: 输出文本的目录，默认为 './outputs'。
- `--device`: 指定用于翻译的设备 (例如, 'cpu', 'cuda')，默认为 'cpu'。
- `--beam-size`: 指定beam搜索的大小，默认为 4。
```

2. 进行简繁中文转换：
```bash
    python ChineseConvert.py --input-file-path=INPUT_FILE_PATH --output-file-path=OUTPUT_FILE_PATH --conversion-type=CONVERSION_TYPE
```

其中，参数描述如下：
- `--input-file-path`: 需要进行简繁转换的文件的路径及名称。
- `--output-file-path`: 转换完成后的文件保存路径及名称。
- `--conversion-type`: 转换类型，支持两个选项：
    - `t2s`: 繁体转简体 (默认选项)
    - `s2t`: 简体转繁体

### 测试
- 已在本地环境对CLI进行了多次测试，验证了模型加载、翻译以及文件读写功能。
- 已对中文简繁转换功能进行了测试，验证了各种情况下的转换结果。


